### PR TITLE
Build binaries and load plugin on Windows

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -319,7 +318,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 	// run from.
 	commands := make([]string, len(lPlugin.Details.Exec))
 	for i, e := range lPlugin.Details.Exec {
-		commands[i] = path.Join(lPlugin.Details.ExecPath, e)
+		commands[i] = filepath.Join(lPlugin.Details.ExecPath, e)
 	}
 	ePlugin, err := plugin.NewExecutablePlugin(
 		p.GenerateArgs(int(log.GetLevel())),

--- a/mgmt/rest/plugin.go
+++ b/mgmt/rest/plugin.go
@@ -30,7 +30,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -193,7 +192,7 @@ func writeFile(filename string, b []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	f, err := os.Create(path.Join(dir, filename))
+	f, err := os.Create(filepath.Join(dir, filename))
 	if err != nil {
 		return "", err
 	}

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -19,4 +19,10 @@ export GOARCH=amd64
 "${__dir}/build_snap.sh" &
 "${__dir}/build_plugins.sh" &
 
+export GOOS=windows
+export GOARCH=amd64
+"${__dir}/build_snap.sh" &
+"${__dir}/build_plugins.sh" &
+
+
 wait

--- a/scripts/build_plugin.sh
+++ b/scripts/build_plugin.sh
@@ -35,6 +35,9 @@ fi
 
 plugin_src_path=$1
 plugin_name=$(basename "${plugin_src_path}")
+if [[ "${GOOS}" == "windows" ]]; then
+  plugin_name="${plugin_name}.exe"
+fi
 go_build=(go build -a -ldflags "-w")
 
 _debug "plugin source: ${plugin_src_path}"

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -38,8 +38,8 @@ _info "git commit: $(git log --pretty=format:"%H" -1)"
 export CGO_ENABLED=0
 
 # rebuild binaries:
-export GOOS=${GOOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}
-export GOARCH=${GOARCH:-"amd64"}
+export GOOS=${GOOS:-$(go env GOOS)}
+export GOARCH=${GOARCH:-$(go env GOARCH)}
 
 OS=$(uname -s)
 if [[ "${OS}" == "Darwin" ]]; then
@@ -58,5 +58,5 @@ else
 fi
 
 mkdir -p "${build_path}/plugins"
-_info "building plugins for ${GOOS}/${GOARCH} in ${p} parallels"
+_info "building plugins for ${GOOS}/${GOARCH} in ${p} parallel processes"
 find "${__proj_dir}/plugin/" -type d -iname "snap-*" -print0 | xargs -0 -n 1 -P $p -I{} "${__dir}/build_plugin.sh" {}

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -48,7 +48,14 @@ else
   build_path="${__proj_dir}/build/${GOOS}/${GOARCH}"
 fi
 
+snaptel="snaptel"
+snapteld="snapteld"
+if [[ "${GOOS}" == "windows" ]]; then
+  snaptel="${snaptel}.exe"
+  snapteld="${snapteld}.exe"
+fi
+
 mkdir -p "${build_path}"
-_info "building snapteld/snaptel for ${GOOS}/${GOARCH}"
-"${go_build[@]}" -o "${build_path}/snapteld" . || exit 1
-(cd "${__proj_dir}/cmd/snaptel" && "${go_build[@]}" -o "${build_path}/snaptel" . || exit 1)
+_info "building snapteld/${snaptel} for ${GOOS}/${GOARCH}"
+"${go_build[@]}" -o "${build_path}/${snapteld}" . || exit 1
+(cd "${__proj_dir}/cmd/snaptel" && "${go_build[@]}" -o "${build_path}/${snaptel}" . || exit 1)

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -39,8 +39,8 @@ _info "git commit: $(git log --pretty=format:"%H" -1)"
 export CGO_ENABLED=0
 
 # rebuild binaries:
-export GOOS=${GOOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}
-export GOARCH=${GOARCH:-"amd64"}
+export GOOS=${GOOS:-$(go env GOOS)}
+export GOARCH=${GOARCH:-$(go env GOARCH)}
 
 if [[ "${GOARCH}" == "amd64" ]]; then
   build_path="${__proj_dir}/build/${GOOS}/x86_64"


### PR DESCRIPTION
Fixes #26, #27 

Summary of changes:
- Makes existing bash build scripts work as expected on Windows
- Enables loading plugins
  - solving the file note found issue

Testing done:
- Manual

Building binaries: 
![img](https://www.evernote.com/l/AA0mXyIpJFJKUIQBb6N1NXmFrPsPONTJY2UB/image.png)

Loading plugins:
![img2](https://www.dropbox.com/s/5c3tvss0vz9t45m/create-task.gif?raw=1)

cc: @thomastaylor312 @jessemillar @mathewlk 