### PR TITLE
WIP - DO NOT MERGE - removes duplicate call to kill

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -513,8 +513,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 	}
 
 	// Added so clients can adequately clean up connections
-	ap.client.Kill("Retrieved necessary plugin info")
-	err = ePlugin.Kill()
+	err = ap.client.Kill("Retrieved necessary plugin info")
 	if err != nil {
 		pmLogger.WithFields(log.Fields{
 			"_block": "load-plugin",


### PR DESCRIPTION
Fixes #26

Summary of changes:
- avoids calling kill twice during the plugin load process

Testing done:
- manual

cc: @mathewlk 
